### PR TITLE
Update Mastodon workflow hashtags and fix UI spacing

### DIFF
--- a/.github/workflows/merge-announcement.yml
+++ b/.github/workflows/merge-announcement.yml
@@ -16,7 +16,7 @@ jobs:
           
           Commit: ${{ github.event.head_commit.url }}
           
-          #Bash #Scripting #GithubActions #DevOps"
+          #Bash #Go #Scripting #DevOps #CloudEngineering"
 
           curl -X POST https://mastodon.social/api/v1/statuses \
             -H "Authorization: Bearer ${{ secrets.MASTODON_TOKEN }}" \

--- a/aws/aws-switcher/main.go
+++ b/aws/aws-switcher/main.go
@@ -58,7 +58,7 @@ func main() {
 
 	// Display current active organization
 	fmt.Println("╔═══════════════════════════════════════════════════════╗")
-	fmt.Println("║          AWS Account Organization Switcher           ║")
+	fmt.Println("║          AWS Account Organization Switcher            ║")
 	fmt.Println("╚═══════════════════════════════════════════════════════╝")
 	fmt.Println()
 


### PR DESCRIPTION
Changes:
- Replace #GithubActions with #Go in workflow hashtags
- Fix spacing alignment in AWS switcher UI header

The workflow now better reflects the repository content which includes Go tools alongside Bash scripts.